### PR TITLE
Enables comment toggling

### DIFF
--- a/Comments.tmPreferences
+++ b/Comments.tmPreferences
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+   <key>name</key>
+   <string>Comment</string>
+   <key>scope</key>
+   <string>source.env</string>
+   <key>settings</key>
+   <dict>
+      <key>shellVariables</key>
+      <array>
+         <dict>
+            <key>name</key>
+            <string>TM_COMMENT_START</string>
+            <key>value</key>
+            <string># </string>
+         </dict>
+      </array>
+   </dict>
+   <key>uuid</key>
+   <string>44fe4156-1fa6-4b0a-a975-0ac1fe95b2e5</string>
+</dict>
+</plist>


### PR DESCRIPTION
Adds the ability to toggle comments using the comment toggle keyboard shortcut (default `[cmd + /]`).
