### PR TITLE
Add support to .env.staging file

### DIFF
--- a/DotENV.YAML-tmLanguage
+++ b/DotENV.YAML-tmLanguage
@@ -19,7 +19,8 @@ fileTypes: [
   ".env.production",
   ".env.production.local",
   ".env.dusk.local",
-  ".flaskenv"
+  ".flaskenv",
+  ".env.staging"
 ]
 uuid: 09d4e117-0975-453d-a74b-c2e525473f97
 

--- a/DotENV.tmLanguage
+++ b/DotENV.tmLanguage
@@ -20,6 +20,7 @@
 		<string>.env.production.local</string>
 		<string>.env.dusk.local</string>
 		<string>.flaskenv</string>
+		<string>.env.staging</string>
 	</array>
 	<key>name</key>
 	<string>DotENV</string>


### PR DESCRIPTION
I see `.env.test` more related to _automatic_ testing environments rather than user-related envs like UAT.

Found myself doing lots of `CTRL + SHIFT + P`, _set syntax_, _dotenv_. Thought adding support would be nice to have.