### PR TITLE
Added half missing ".env.testing"

### DIFF
--- a/DotENV.tmLanguage
+++ b/DotENV.tmLanguage
@@ -12,6 +12,7 @@
 		<string>.env.example</string>
 		<string>.env.test</string>
 		<string>.env.test.local</string>
+		<string>.env.testing</string>
 		<string>.env.dev</string>
 		<string>.env.development</string>
 		<string>.env.development.local</string>


### PR DESCRIPTION
Added the missing sibling of `.env.testing` to `DotENV.YAML-tmLanguage`

It was added to `DotENV.tmLanguage` with the #9 pull request, but was forgotten from this file